### PR TITLE
Update build process to use the settings.json's build.outputBase path…

### DIFF
--- a/config/grunt/aliastask/build.js
+++ b/config/grunt/aliastask/build.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
 		"webfont:staging"
 	]);
 
-	grunt.registerTask("build:prod", [
+	grunt.registerTask("build:production", [
 		"clean",
 		"webfont:prod"
 	]);

--- a/config/webpack/webpack-prod.js
+++ b/config/webpack/webpack-prod.js
@@ -39,16 +39,16 @@ module.exports = function (env) {
 		DATA_ROOT: customSettings.url.prod.dataRoot
 	});
 	const resRoot = metadata.resourcesRoot;
-	const outputBase = customSettings.build.outputBase.prod;
+	const outputBase = path.join(helpers.root(env.resourcesRoot, customSettings.build.outputBase.prod));
 	const paths = {
 		input: {
 			contentRoot: path.join(resRoot, customSettings.resources.contentRoot),
 			dataRoot: path.join(resRoot, customSettings.resources.dataRoot)
 		},
 		output: {
-			content: helpers.root(path.join(outputBase, 'asset')),
-			site: helpers.root(path.join(outputBase, 'site')),
-			siteData: helpers.root(path.join(outputBase, 'site', 'site-data'))
+			content: path.join(outputBase, 'asset'),
+			site: path.join(outputBase, 'site'),
+			siteData: path.join(outputBase, 'site', 'site-data')
 		}
 	};
 	const style = customSettings.style;

--- a/config/webpack/webpack-staging.js
+++ b/config/webpack/webpack-staging.js
@@ -39,16 +39,16 @@ module.exports = function (env) {
 		DATA_ROOT: customSettings.url.staging.dataRoot
 	});
 	const resRoot = metadata.resourcesRoot;
-	const outputBase = customSettings.build.outputBase.staging;
+	const outputBase = path.join(helpers.root(env.resourcesRoot, customSettings.build.outputBase.staging));
 	const paths = {
 		input: {
 			contentRoot: path.join(resRoot, customSettings.resources.contentRoot),
 			dataRoot: path.join(resRoot, customSettings.resources.dataRoot)
 		},
 		output: {
-			content: helpers.root(path.join(outputBase, 'asset')),
-			site: helpers.root(path.join(outputBase, 'site')),
-			siteData: helpers.root(path.join(outputBase, 'site', 'site-data'))
+			content: path.join(outputBase, 'asset'),
+			site: path.join(outputBase, 'site'),
+			siteData: path.join(outputBase, 'site', 'site-data')
 		}
 	};
 	const style = customSettings.style;

--- a/resources-example/settings.json
+++ b/resources-example/settings.json
@@ -5,8 +5,8 @@
 			"port": 3000
 		},
 		"outputBase": {
-			"prod": "dist/prod",
-			"staging": "dist/staging"
+			"prod": "../dist/prod",
+			"staging": "../dist/staging"
 		}
 	},
 	"font": [

--- a/site-config.README.md
+++ b/site-config.README.md
@@ -27,7 +27,7 @@ There is an example file at `resources-example/settings.json`.
 				- `port` - (`3000`) - `Number`
 					- The port to use.
 		- `outputBase` - `Required`
-			- Output locations - this is base directory where compiled output will go.
+			- Output locations - this is base directory where compiled output will go, relative to the location of the settings file itself.
 				- `prod` - `Required` - `String`
 					- The target location for output when building for prod, i.e. `dist/prod`
 				- `staging` - `Required` - `String`


### PR DESCRIPTION
… as relative to the settings.json file itself, not the lm-generator-base root. This is more intuitive. Also, this fixes the prod build which was broken.