### PR TITLE
Feature/sass overrides fix

### DIFF
--- a/config/webpack/plugin/sass-overrides-plugin.js
+++ b/config/webpack/plugin/sass-overrides-plugin.js
@@ -4,23 +4,35 @@ const glob = require('glob');
 const verboseLog = new (require('@build-utils/verbose-log'))('SassOverridesPlugin');
 
 function SassOverridesPlugin(cfg, verbose) {
+    verbose && verboseLog.enable();
+
     this.cfg = cfg;
-    this.targetSrcDir = path.resolve(
-        cfg.path.resrcRoot,
-        cfg.appSettings.style.overridesBaseDir
-    );
+    this.skip = false;
     this.targetOutputDir = path.resolve(
         cfg.path.pkgJsonDirs.sassGeneratedRoot,
         cfg.path.pkgJsonDirs.sassOverridesBase
     );
-    this.skip = false;
 
-    verbose && verboseLog.enable();
+    if(cfg.appSettings
+        && cfg.appSettings.style
+        && cfg.appSettings.style.overridesBaseDir
+        && cfg.appSettings.style.overridesEntryPoint) {
+        this.targetSrcDir = path.resolve(
+            cfg.path.resrcRoot,
+            cfg.appSettings.style.overridesBaseDir
+        );
+        this.hasOverrides = true;
+    }
 }
 
 SassOverridesPlugin.prototype = {
     apply: function (compiler) {
         let that = this;
+
+        if(!this.hasOverrides) {
+            this.patchMissingOverrides();
+            return;
+        }
 
         compiler.plugin("invalid", function (filename) {
             let outputFiles = glob.sync(path.join(that.targetOutputDir, '**/*')).map(fPath => {
@@ -85,6 +97,20 @@ SassOverridesPlugin.prototype = {
                     resolve();
                 });
         });
+    },
+
+    patchMissingOverrides: function() {
+        try {
+            fs.outputFileSync(
+                path.resolve(
+                    this.targetOutputDir,
+                    this.cfg.path.pkgJsonResrc.sassOverridesEntryPoint
+                ), '/* No overrides were found because the settings object has no "style" property. Refer to the readme for how the settings file should be structured if you believe this is an error. */');
+            verboseLog.log('No custom style overrides defined - Generated empty overrides file instead.');
+        }
+        catch(err) {
+            verboseLog.log('No custom style overrides defined - Failed to generate empty overrides file!!!', err);
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack-dev-server": "^1.16.5",
     "webpack-md5-hash": "0.0.5",
     "webpack-merge": "^0.15.0",
-    "webpack-webfont": "0.0.1-alpha.8"
+    "webpack-webfont": "0.0.1-alpha.10"
   },
   "directories": {
     "app": "app/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lm-generator-base",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Base site generator",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Makes sass overrides optional. Upgrade to newer version of webfont generator that will now no longer infinitely recompile.