### PR TITLE
Loc Svc and Loc Picker fixes

### DIFF
--- a/app/app.scss
+++ b/app/app.scss
@@ -119,6 +119,10 @@ a {
     }
 }
 
+.display-none {
+    display: none !important;
+}
+
 @media screen and (min-width: $screen-xs-min) {
 }
 

--- a/app/module/site-common/component/footer/footer.cmp.html
+++ b/app/module/site-common/component/footer/footer.cmp.html
@@ -1,42 +1,44 @@
 <footer>
-	<div class="grass"></div>
-	<div class="content theme-brand-secondary">
-		<div class="container">
-			<div class="row">
-				<div *ngFor="let section of content.sections" class="footer-section col-xs-12 col-md-3 col-lg-2">
-					<h3>{{section.title}}</h3>
-					<ul>
-						<li *ngFor="let item of section.items">
-							<a *ngIf="item.routerLink" [routerLink]="item.routerLink" [innerHtml]="getSanHtml(item.copy)"></a>
-							<a *ngIf="item.href" [href]="item.href" [innerHtml]="getSanHtml(item.copy)" target="_blank"></a>
-						</li>
-					</ul>
-				</div>
-			</div>
-			<div class="social row">
-				<div class="col-xs-12 col-sm-6 col-md-3 col-lg-2">
-					<h3>{{content?.social?.title}}</h3>
-					<ul>
-						<li *ngFor="let item of content?.social?.items">
-							<a [href]="item.href" target="_blank"><i class="siteIcon siteIcon-{{item.type}}"></i></a>
-						</li>
-					</ul>
-				</div>
-			</div>
-			<div class="locale row">
-				<div class="col-xs-12 col-sm-6 col-md-3 col-lg-2">
-					<locale-switcher></locale-switcher>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="sub-footer">
-		<div class="container">
-			<div class="row">
-				<div class="col-xs-12">
-					&copy;{{getDate()}} {{content?.copyright?.copy}}
-				</div>
-			</div>
-		</div>
-	</div>
+    <div class="grass"></div>
+    <div class="content theme-brand-secondary">
+        <div class="container">
+            <div class="row">
+                <div *ngFor="let section of content.sections" class="footer-section col-xs-12 col-md-3 col-lg-2">
+                    <h3>{{section.title}}</h3>
+                    <ul>
+                        <li *ngFor="let item of section.items">
+                            <a *ngIf="item.routerLink" [routerLink]="item.routerLink"
+                               [innerHtml]="getSanHtml(item.copy)"></a>
+                            <a *ngIf="item.href" [href]="item.href" [innerHtml]="getSanHtml(item.copy)"
+                               target="_blank"></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="social row">
+                <div class="col-xs-12 col-sm-6 col-md-3 col-lg-2">
+                    <h3>{{content?.social?.title}}</h3>
+                    <ul>
+                        <li *ngFor="let item of content?.social?.items">
+                            <a [href]="item.href" target="_blank"><i class="siteIcon siteIcon-{{item.type}}"></i></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="locale row" [ngClass]="{'display-none': !localeSwitcher || !localeSwitcher.available}">
+                <div class="col-xs-12 col-sm-6 col-md-3 col-lg-2">
+                    <locale-switcher #localeSwitcher></locale-switcher>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sub-footer">
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-12">
+                    &copy;{{getDate()}} {{content?.copyright?.copy}}
+                </div>
+            </div>
+        </div>
+    </div>
 </footer>

--- a/app/module/site-common/component/footer/footer.cmp.ts
+++ b/app/module/site-common/component/footer/footer.cmp.ts
@@ -1,52 +1,53 @@
-import { Component, OnDestroy, ViewEncapsulation } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { Subscription } from 'rxjs';
+import {Component, OnDestroy, ViewChild, ViewContainerRef, ViewEncapsulation} from '@angular/core';
+import {DomSanitizer} from '@angular/platform-browser';
+import {Subscription} from 'rxjs';
 
-import { Config_Svc, LocalizableContent_Mdl, Localization_Svc } from "lm/site-common";
+import {Config_Svc, LocalizableContent_Mdl, Localization_Svc} from "lm/site-common";
 
 @Component({
-	selector: 'site-footer',
-	template: require('./footer.cmp.html'),
-	styles: [require('./footer.cmp.scss')],
-	encapsulation: ViewEncapsulation.None
+    selector: 'site-footer',
+    template: require('./footer.cmp.html'),
+    styles: [require('./footer.cmp.scss')],
+    encapsulation: ViewEncapsulation.None
 })
 
 export class Footer_Cmp implements OnDestroy {
-	content: any = {};
+    content: any = {};
+    @ViewChild('localeSwitcher', {read: ViewContainerRef}) localeSwitcher: ViewContainerRef;
 
-	private config: any;
-	private configSvcSub: Subscription;
-	private localizableContentObj: LocalizableContent_Mdl;
+    private config: any;
+    private configSvcSub: Subscription;
+    private localizableContentObj: LocalizableContent_Mdl;
 
-	constructor(private configSvc: Config_Svc,
-	            private localizationSvc: Localization_Svc,
-	            private sanitizer: DomSanitizer) {
-		this.configSvcSub = this.configSvc.globalConfigUpdate
-			.subscribe(data => {
-				this.onConfigChange(data.config)
-			});
-	}
+    constructor(private configSvc: Config_Svc,
+                private localizationSvc: Localization_Svc,
+                private sanitizer: DomSanitizer) {
+        this.configSvcSub = this.configSvc.globalConfigUpdate
+            .subscribe(data => {
+                this.onConfigChange(data.config)
+            });
+    }
 
-	ngOnDestroy() {
-		this.configSvcSub.unsubscribe();
-		this.localizableContentObj && this.localizableContentObj.unregister();
-	}
+    ngOnDestroy() {
+        this.configSvcSub.unsubscribe();
+        this.localizableContentObj && this.localizableContentObj.unregister();
+    }
 
-	getSanHtml(str) {
-		return this.sanitizer.bypassSecurityTrustHtml(str);
-	}
+    getSanHtml(str) {
+        return this.sanitizer.bypassSecurityTrustHtml(str);
+    }
 
-	getDate() {
-		return new Date().getFullYear();
-	}
+    getDate() {
+        return new Date().getFullYear();
+    }
 
-	private onConfigChange(config) {
-		if (!config) {
-			return;
-		}
-		this.config = config.component.footer;
-		this.localizableContentObj && this.localizableContentObj.unregister();
-		this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
-		this.content = this.localizableContentObj.content;
-	}
+    private onConfigChange(config) {
+        if (!config) {
+            return;
+        }
+        this.config = config.component.footer;
+        this.localizableContentObj && this.localizableContentObj.unregister();
+        this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
+        this.content = this.localizableContentObj.content;
+    }
 }

--- a/app/module/site-common/component/header/header.cmp.html
+++ b/app/module/site-common/component/header/header.cmp.html
@@ -1,17 +1,19 @@
 <header>
-	<div class="controls">
-		<main-menu-toggle>
-			<i class="siteIcon siteIcon-menu menu-toggle"></i> {{content?.mainMenuToggle?.label ? content.mainMenuToggle.label : ''}}
-		</main-menu-toggle>
-		<a [routerLink]="['/']"
-		   [ngSwitch]="config?.type"
-		   *ngIf="content.logo"
-		   class="logo">
-			<logo [config]="content.logo"></logo>
-		</a>
-	</div>
-	<div class="actions">
-		<!--<button *ngIf="content && content.cta">{{content.cta}}</button>-->
-		<locale-switcher></locale-switcher>
-	</div>
+    <div class="controls">
+        <main-menu-toggle>
+            <i class="siteIcon siteIcon-menu menu-toggle"></i>
+            {{content?.mainMenuToggle?.label ? content.mainMenuToggle.label : ''}}
+        </main-menu-toggle>
+        <a [routerLink]="['/']"
+           [ngSwitch]="config?.type"
+           *ngIf="content.logo"
+           class="logo">
+            <logo [config]="content.logo"></logo>
+        </a>
+    </div>
+    <div class="actions">
+        <!--<button *ngIf="content && content.cta">{{content.cta}}</button>-->
+        <locale-switcher #localeSwitcher
+                         [ngClass]="{'display-none': !localeSwitcher || !localeSwitcher.available}"></locale-switcher>
+    </div>
 </header>

--- a/app/module/site-common/component/header/header.cmp.ts
+++ b/app/module/site-common/component/header/header.cmp.ts
@@ -1,42 +1,43 @@
-import { Component, ViewEncapsulation, OnDestroy } from '@angular/core';
-import { Subscription } from 'rxjs';
+import {Component, ViewChild, ViewContainerRef, ViewEncapsulation, OnDestroy} from '@angular/core';
+import {Subscription} from 'rxjs';
 
-import { Config_Svc, LocalizableContent_Mdl, Localization_Svc } from 'lm/site-common';
+import {Config_Svc, LocalizableContent_Mdl, Localization_Svc} from 'lm/site-common';
 
 @Component({
-	selector: 'site-header',
-	template: require('./header.cmp.html'),
-	styles: [require('./header.cmp.scss')],
-	encapsulation: ViewEncapsulation.None
+    selector: 'site-header',
+    template: require('./header.cmp.html'),
+    styles: [require('./header.cmp.scss')],
+    encapsulation: ViewEncapsulation.None
 })
 
-export class Header_Cmp implements OnDestroy{
-	content: any = {};
+export class Header_Cmp implements OnDestroy {
+    content: any = {};
+    @ViewChild('localeSwitcher', {read: ViewContainerRef}) localeSwitcher: ViewContainerRef;
 
-	private localizableContentObj: LocalizableContent_Mdl;
-	private config: any;
-	private configSvcSub: Subscription;
+    private localizableContentObj: LocalizableContent_Mdl;
+    private config: any;
+    private configSvcSub: Subscription;
 
-	constructor(private configSvc: Config_Svc,
-	            private localizationSvc: Localization_Svc) {
-		this.configSvcSub = this.configSvc.globalConfigUpdate
-			.subscribe(data => {
-				this.onConfigChange(data.config);
-			});
-	}
+    constructor(private configSvc: Config_Svc,
+                private localizationSvc: Localization_Svc) {
+        this.configSvcSub = this.configSvc.globalConfigUpdate
+            .subscribe(data => {
+                this.onConfigChange(data.config);
+            });
+    }
 
-	ngOnDestroy() {
-		this.configSvcSub.unsubscribe();
-		this.localizableContentObj && this.localizableContentObj.unregister();
-	}
+    ngOnDestroy() {
+        this.configSvcSub.unsubscribe();
+        this.localizableContentObj && this.localizableContentObj.unregister();
+    }
 
-	private onConfigChange(config) {
-		if (!config) {
-			return;
-		}
-		this.config = config.component.header;
-		this.localizableContentObj && this.localizableContentObj.unregister();
-		this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
-		this.content = this.localizableContentObj.content;
-	}
+    private onConfigChange(config) {
+        if (!config) {
+            return;
+        }
+        this.config = config.component.header;
+        this.localizableContentObj && this.localizableContentObj.unregister();
+        this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
+        this.content = this.localizableContentObj.content;
+    }
 }

--- a/app/module/site-common/component/locale-switcher/locale-switcher.cmp.html
+++ b/app/module/site-common/component/locale-switcher/locale-switcher.cmp.html
@@ -1,14 +1,14 @@
-<div class="locale-switcher">
-	<button (click)="toggle()" class="utility">
-		<i class="siteIcon siteIcon-globe"></i>
-		{{this.content.title}}
-	</button>
-	<ul *ngIf="active">
-		<li *ngFor="let locale of locales"
-			(click)="handleLocaleClick(locale)">
-			<button>
-				{{locale.name}} ({{locale.locale}})
-			</button>
-		</li>
-	</ul>
+<div class="locale-switcher" *ngIf="available">
+    <button (click)="toggle()" class="utility">
+        <i class="siteIcon siteIcon-globe"></i>
+        {{this.content.title}}
+    </button>
+    <ul *ngIf="active">
+        <li *ngFor="let locale of locales"
+            (click)="handleLocaleClick(locale)">
+            <button>
+                {{locale.name}} ({{locale.locale}})
+            </button>
+        </li>
+    </ul>
 </div>

--- a/app/module/site-common/component/locale-switcher/locale-switcher.cmp.ts
+++ b/app/module/site-common/component/locale-switcher/locale-switcher.cmp.ts
@@ -1,52 +1,57 @@
-import { Component } from '@angular/core';
-import { Subscription } from 'rxjs';
+import {Component} from '@angular/core';
+import {Subscription} from 'rxjs';
 
-import { Config_Svc, LocalizableContent_Mdl, Localization_Svc } from "lm/site-common";
+import {Config_Svc, LocalizableContent_Mdl, Localization_Svc} from "lm/site-common";
 
 @Component({
-	selector: 'locale-switcher',
-	template: require('./locale-switcher.cmp.html'),
-	styles: [require('./locale-switcher.cmp.scss')]
+    selector: 'locale-switcher',
+    template: require('./locale-switcher.cmp.html'),
+    styles: [require('./locale-switcher.cmp.scss')]
 })
 export class LocaleSwitcher_Cmp {
-	locale: any;
-	locales: Array<any> = [];
-	active: boolean = false;
-	content: any = {};
+    //Active refers to open/closed state
+    active: boolean = false;
+    //Available refers to whether or not to even show the selector. Sites with < 2 locales should not show pickers and
+    //this value is set accordingly
+    available: boolean = false;
+    content: any = {};
+    locale: any;
+    locales: Array<any> = [];
 
-	private localizableContentObj: LocalizableContent_Mdl;
-	private config: any;
-	private configSvcSub: Subscription;
+    private localizableContentObj: LocalizableContent_Mdl;
+    private config: any;
+    private configSvcSub: Subscription;
 
-	constructor(private configSvc: Config_Svc,
-	            private localizationSvc: Localization_Svc) {
-		this.locale = localizationSvc.getCurrentLocale();
-		this.localizationSvc.localeUpdatedEvent.subscribe(locale => {
-			this.locale = locale;
-			this.locales = this.localizationSvc.getLocales();
-		});
-		this.configSvcSub = this.configSvc.globalConfigUpdate
-			.subscribe(data => {
-				this.onConfigChange(data.config);
-			});
-	}
+    constructor(private configSvc: Config_Svc,
+                private localizationSvc: Localization_Svc) {
+        this.locale = localizationSvc.getCurrentLocale();
+        this.localizationSvc.localeUpdatedEvent.subscribe(locale => {
+            this.locale = locale;
+            this.locales = this.localizationSvc.getLocales();
+            this.available = this.locales.length > 1;
+        });
+        this.configSvcSub = this.configSvc.globalConfigUpdate
+            .subscribe(data => {
+                this.onConfigChange(data.config);
+            });
+    }
 
-	toggle() {
-		this.active = !this.active;
-	}
+    toggle() {
+        this.active = !this.active;
+    }
 
-	handleLocaleClick(locale:any) {
-		this.localizationSvc.setLocale(locale.locale);
-		this.toggle();
-	}
+    handleLocaleClick(locale: any) {
+        this.localizationSvc.setLocale(locale.locale);
+        this.toggle();
+    }
 
-	private onConfigChange(config) {
-		if (!config) {
-			return;
-		}
-		this.config = config.component.localeSwitcher;
-		this.localizableContentObj && this.localizableContentObj.unregister();
-		this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
-		this.content = this.localizableContentObj.content;
-	}
+    private onConfigChange(config) {
+        this.config = config && config.component && config.component.localeSwitcher;
+        if (!this.config) {
+            return;
+        }
+        this.localizableContentObj && this.localizableContentObj.unregister();
+        this.localizableContentObj = this.localizationSvc.registerContent(this.config.content);
+        this.content = this.localizableContentObj.content;
+    }
 }

--- a/app/module/site-common/model/localizable-content.mdl.ts
+++ b/app/module/site-common/model/localizable-content.mdl.ts
@@ -1,54 +1,56 @@
 export class LocalizableContent_Mdl {
-	content: any = {};
+    content: any = {};
 
-	private currentLocale: string;
+    private currentLocale: string;
 
-	constructor(private baseContentObj: any,
-	            private locale: string,
-				private unregisterCallback: Function,
-				private defaultLocale?: string) {
-		this.setLocale(locale);
-	}
+    constructor(private baseContentObj: any,
+                private locale: string,
+                private unregisterCallback: Function,
+                private defaultLocale?: string) {
+        this.setLocale(locale);
+    }
 
-	setLocale(locale: string) {
-		let target = this.content;
-		let src;
+    setLocale(locale: string) {
+        let target = this.content;
+        let src;
 
-		if(locale === this.currentLocale) {
-			return;
-		}
+        if (Object.keys(this.content).length && locale === this.currentLocale) {
+            return;
+        }
 
-		src = this.baseContentObj[locale];
-		if (!src && this.defaultLocale) {
-			src = this.baseContentObj[this.defaultLocale];
-		}
-		if (!src) {
-			src = this.baseContentObj;
-		}
+        if(this.baseContentObj) {
+            src = this.baseContentObj[locale];
+            if (!src && this.defaultLocale) {
+                src = this.baseContentObj[this.defaultLocale];
+            }
+            if (!src) {
+                src = this.baseContentObj;
+            }
+        }
 
-		this.currentLocale = locale;
+        this.currentLocale = locale;
 
-		for(let key in target){
-			if(target.hasOwnProperty(key)) {
-				delete target[key];
-			}
-		}
+        for (let key in target) {
+            if (target.hasOwnProperty(key)) {
+                delete target[key];
+            }
+        }
 
-		for(let key in src) {
-			if(src.hasOwnProperty(key)) {
-				target[key] = src[key];
-			}
-		}
-	}
+        for (let key in src) {
+            if (src.hasOwnProperty(key)) {
+                target[key] = src[key];
+            }
+        }
+    }
 
-	setDefaultLocale(locale: string) {
-		this.defaultLocale = locale;
-		if (!this.locale) {
-			this.setLocale(locale);
-		}
-	}
+    setDefaultLocale(locale: string) {
+        this.defaultLocale = locale;
+        if (!this.locale) {
+            this.setLocale(locale);
+        }
+    }
 
-	unregister() {
-		this.unregisterCallback(this);
-	}
+    unregister() {
+        this.unregisterCallback(this);
+    }
 }

--- a/app/module/site-common/service/localization.svc.ts
+++ b/app/module/site-common/service/localization.svc.ts
@@ -1,133 +1,133 @@
-import { Inject, Injectable } from '@angular/core';
-import { BehaviorSubject, Subscription } from 'rxjs';
+import {Inject, Injectable} from '@angular/core';
+import {BehaviorSubject, Subscription} from 'rxjs';
 
-import { Config_Svc, ConfigTypes } from './config.svc';
-import { LocalizableContent_Mdl, StorageService } from 'lm/site-common';
+import {Config_Svc, ConfigTypes} from './config.svc';
+import {LocalizableContent_Mdl, StorageService} from 'lm/site-common';
 
 @Injectable()
 export class Localization_Svc {
-	localeUpdatedEvent: BehaviorSubject<any> = new BehaviorSubject<any>({});
+    localeUpdatedEvent: BehaviorSubject<any> = new BehaviorSubject<any>({});
 
-	private currentLocale: any = {};
-	private locItems: Array<LocalizableContent_Mdl> = [];
-	private storageKey: string = 'locale';
-	private locConfig: any = {};
-	private configSvcSub: Subscription;
-	private defaultLocale: string;
+    private currentLocale: any = {};
+    private locItems: Array<LocalizableContent_Mdl> = [];
+    private storageKey: string = 'locale';
+    private locConfig: any = {};
+    private configSvcSub: Subscription;
+    private defaultLocale: string;
 
-	constructor(private configSvc: Config_Svc,
-				@Inject(StorageService) private storageSvc){
-		this.configSvcSub = this.configSvc.appConfigUpdate
-			.subscribe(data => {
-				this.handleConfigChange(data.config);
-			});
-	}
+    constructor(private configSvc: Config_Svc,
+                @Inject(StorageService) private storageSvc) {
+        this.configSvcSub = this.configSvc.appConfigUpdate
+            .subscribe(data => {
+                this.handleConfigChange(data.config);
+            });
+    }
 
-	/**
-	 * Checks for existing locale in the config. If it's not registered in the config, abort mission.
-	 * If it exists, set the currentLocale object, update all registered locItems, and write hte new locale to
-	 * the storage service. Then, fire an event that we've updated.
-	 *
-	 * @param locale {string}   The locale to switch to as a string, i.e. "en-us"
-	 */
-	setLocale(locale: string) {
-		let localeObject = this.getLocaleFromConfig(locale);
+    /**
+     * Checks for existing locale in the config. If it's not registered in the config, abort mission.
+     * If it exists, set the currentLocale object, update all registered locItems, and write hte new locale to
+     * the storage service. Then, fire an event that we've updated.
+     *
+     * @param locale {string}   The locale to switch to as a string, i.e. "en-us"
+     */
+    setLocale(locale: string) {
+        let localeObject = this.getLocaleFromConfig(locale);
 
-		if (!locale || locale === this.currentLocale.name || !localeObject) {
-			if (!localeObject && ENV !== 'production') {
-				console.warn(`Tried to set locale ${locale}, which is not a registered locale in the config. Aborting.`);
-			}
-			return;
-		}
-		this.currentLocale = localeObject;
-		this.locItems.forEach(el => {
-			el.setLocale(locale);
-		});
-		this.storageSvc.set(this.storageKey, localeObject.locale);
-		this.localeUpdatedEvent.next(localeObject);
-	}
+        if (!locale || locale === this.currentLocale.name || !localeObject) {
+            if (!localeObject && ENV !== 'production') {
+                console.warn(`Tried to set locale ${locale}, which is not a registered locale in the config. Aborting.`);
+            }
+            return;
+        }
+        this.currentLocale = localeObject;
+        this.locItems.forEach(el => {
+            el.setLocale(locale);
+        });
+        this.storageSvc.set(this.storageKey, localeObject.locale);
+        this.localeUpdatedEvent.next(localeObject);
+    }
 
-	getCurrentLocale() {
-		return this.currentLocale;
-	}
+    getCurrentLocale() {
+        return this.currentLocale;
+    }
 
-	getLocales():Array<string> {
-		return this.locConfig.locales;
-	}
+    getLocales(): Array<string> {
+        return this.locConfig.locales;
+    }
 
-	/**
-	 * Registers a given object as a "localizable content object". This means that it is an object where all first-level
-	 * keys are locales, for example "en-us" and "es-ar". Each key should contain an identical structure so that
-	 * locale objects can switch from one language to the next. Localizable objects can alternately be created without
-	 * any first-level locale keys as the model itself is smart enough to default to non-locale keys on the object  when
-	 * it can't find the either a desired key or the default language key allowing this to be resilient in case a
-	 * non-localized content object is passed.
-	 * Note that the returned object is a wrapper LocalizableContent_Mdl object that automates language switching on
-	 * the content for the consumer.
-	 *
-	 * @param content   {object}    An object to be registered as a new localizable content object.
-	 * @returns         {LocalizableContent_Mdl}
-	 */
-	registerContent(content: any) {
-		let locItem = new LocalizableContent_Mdl(content, this.currentLocale.locale, this.unregisterContent.bind(this), this.defaultLocale);
+    /**
+     * Registers a given object as a "localizable content object". This means that it is an object where all first-level
+     * keys are locales, for example "en-us" and "es-ar". Each key should contain an identical structure so that
+     * locale objects can switch from one language to the next. Localizable objects can alternately be created without
+     * any first-level locale keys as the model itself is smart enough to default to non-locale keys on the object  when
+     * it can't find either a desired key or the default language key allowing this to be resilient in case a
+     * non-localized content object is passed.
+     * Note that the returned object is a wrapper LocalizableContent_Mdl object that automates language switching on
+     * the content for the consumer.
+     *
+     * @param content   {object}    An object to be registered as a new localizable content object.
+     * @returns         {LocalizableContent_Mdl}
+     */
+    registerContent(content: any) {
+        let locItem = new LocalizableContent_Mdl(content, this.currentLocale.locale, this.unregisterContent.bind(this), this.defaultLocale);
 
-		this.locItems.push(locItem);
-		return locItem;
-	}
+        this.locItems.push(locItem);
+        return locItem;
+    }
 
-	getDefaultLocale() {
-		return this.defaultLocale;
-	}
+    getDefaultLocale() {
+        return this.defaultLocale;
+    }
 
-	private setDefaultLocale(locale: string) {
-		this.locItems.forEach(el => {
-			el.setDefaultLocale(locale);
-		});
-	}
+    private setDefaultLocale(locale: string) {
+        this.locItems.forEach(el => {
+            el.setDefaultLocale(locale);
+        });
+    }
 
-	/**
-	 * Retrieve a locale from the local locConfig object which was imported from the global app config. This is a
-	 * descriptor object that contains the id and display name of the locale.
-	 *
-	 * @param locale    {string}    The name of the locale to search for
-	 * @returns         {null}      Returns null if no locale is found matching the request
-	 */
-	private getLocaleFromConfig(locale: string) {
-		let locales = this.locConfig && this.locConfig.locales;
-		let foundLocale = null;
+    /**
+     * Retrieve a locale from the local locConfig object which was imported from the global app config. This is a
+     * descriptor object that contains the id and display name of the locale.
+     *
+     * @param locale    {string}    The name of the locale to search for
+     * @returns         {null}      Returns null if no locale is found matching the request
+     */
+    private getLocaleFromConfig(locale: string) {
+        let locales = this.locConfig && this.locConfig.locales;
+        let foundLocale = null;
 
-		if (locales && Array.isArray(locales)) {
-			foundLocale = locales.filter(el => {
-				return el.locale === locale;
-			})[0];
-		}
+        if (locales && Array.isArray(locales)) {
+            foundLocale = locales.filter(el => {
+                return el.locale === locale;
+            })[0];
+        }
 
-		return foundLocale;
-	}
+        return foundLocale;
+    }
 
-	/**
-	 * When config changes happen, both current locale can update (if there wasn't one set, for instance) and default
-	 * locale can change as well. Need to update the locConfig to match the latest incoming data.
-	 *
-	 * @param config    {object}   The new config object to handle
-	 */
-	private handleConfigChange(config: any) {
-		let currentDefaultLocale = this.defaultLocale;
-		this.locConfig = config.localization || {};
-		this.defaultLocale = this.locConfig.default;
-		this.setLocale(this.storageSvc.get(this.storageKey) || this.currentLocale && this.currentLocale.locale || this.locConfig.default);
-		if(currentDefaultLocale !== this.defaultLocale) {
-			this.setDefaultLocale(this.defaultLocale);
-		}
-	}
+    /**
+     * When config changes happen, both current locale can update (if there wasn't one set, for instance) and default
+     * locale can change as well. Need to update the locConfig to match the latest incoming data.
+     *
+     * @param config    {object}   The new config object to handle
+     */
+    private handleConfigChange(config: any) {
+        let currentDefaultLocale = this.defaultLocale;
+        this.locConfig = config.localization || {};
+        this.defaultLocale = this.locConfig.default;
+        this.setLocale(this.storageSvc.get(this.storageKey) || this.currentLocale && this.currentLocale.locale || this.locConfig.default);
+        if (currentDefaultLocale !== this.defaultLocale) {
+            this.setDefaultLocale(this.defaultLocale);
+        }
+    }
 
-	/**
-	 * Unregisters a content object. This is needed to remove content from the list of localizable content objects
-	 * that are updated as language switches occur.
-	 *
-	 * @param content
-	 */
-	private unregisterContent(content: LocalizableContent_Mdl) {
-		this.locItems.splice(this.locItems.indexOf(content), 1);
-	}
+    /**
+     * Unregisters a content object. This is needed to remove content from the list of localizable content objects
+     * that are updated as language switches occur.
+     *
+     * @param content
+     */
+    private unregisterContent(content: LocalizableContent_Mdl) {
+        this.locItems.splice(this.locItems.indexOf(content), 1);
+    }
 }


### PR DESCRIPTION
Fixes for bugs around localization issues with the locale picker and localization service. The app should no longer break when a config doesn't have global localization settings or localized content objects (it will default to using whatever base keys are available on a component's config object instead).

Also provides spaces-over-tabs in affected files.