### PR TITLE
v1.0.4

### DIFF
--- a/app/main.browser.ts
+++ b/app/main.browser.ts
@@ -4,8 +4,11 @@ import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {enableProdMode} from '@angular/core';
 import {App_Mod} from './app.mod';
 
-if(ENV === 'production') {
-	enableProdMode();
+if (ENV === 'production' || ENV === 'prod') {
+    enableProdMode();
+}
+if(VERSION) {
+    console.log(`Generator version: ${VERSION}`);
 }
 const platform = platformBrowserDynamic();
 platform.bootstrapModule(App_Mod);

--- a/app/module/site-common/service/config.svc.ts
+++ b/app/module/site-common/service/config.svc.ts
@@ -1,48 +1,48 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
 
 export const ConfigTypes: any = {
-	app: 'app',
-	global: 'global',
-	page: 'page'
+    app: 'app',
+    global: 'global',
+    page: 'page'
 };
 
 @Injectable()
 export class Config_Svc {
-	configUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
-	globalConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
-	pageConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
-	appConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
+    configUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
+    globalConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
+    pageConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
+    appConfigUpdate: BehaviorSubject<any> = new BehaviorSubject<any>({});
 
-	private configs:any = {};
+    private configs: any = {};
 
-	constructor() {
-	}
+    constructor() {
+    }
 
-	setConfig(type, config:any, currentRoute?: any) {
-		let eventData = {
-			type,
-			config,
-			currentRoute
-		};
+    setConfig(type, config: any, currentRoute?: any) {
+        let eventData = {
+            type,
+            config,
+            currentRoute
+        };
 
-		this.configs[type] = config;
-		this.configUpdate.next(eventData);
+        this.configs[type] = config;
+        this.configUpdate.next(eventData);
 
-		switch(type) {
-			case ConfigTypes.app:
-				this.appConfigUpdate.next(eventData);
-				break;
-			case ConfigTypes.global:
-				this.globalConfigUpdate.next(eventData);
-				break;
-			case ConfigTypes.page:
-				this.pageConfigUpdate.next(eventData);
-				break;
-		}
-	}
+        switch (type) {
+            case ConfigTypes.app:
+                this.appConfigUpdate.next(eventData);
+                break;
+            case ConfigTypes.global:
+                this.globalConfigUpdate.next(eventData);
+                break;
+            case ConfigTypes.page:
+                this.pageConfigUpdate.next(eventData);
+                break;
+        }
+    }
 
-	getConfig(type):any {
-		return this.configs[type];
-	}
+    getConfig(type): any {
+        return this.configs[type];
+    }
 }

--- a/app/module/site-common/service/metrics.svc.ts
+++ b/app/module/site-common/service/metrics.svc.ts
@@ -1,108 +1,107 @@
-import { Injectable } from '@angular/core';
-
-import { Config_Svc, ConfigTypes } from "./config.svc";
+import {Injectable} from '@angular/core';
+import {Router, NavigationEnd} from '@angular/router';
+import {Subscription} from 'rxjs';
 
 export const MetricTypes: any = {
-	google: 'google'
+    google: 'google'
 };
 
 const MetricScriptUrls: any = {
-	google: 'https://www.google-analytics.com/analytics.js'
+    google: 'https://www.google-analytics.com/analytics.js'
 };
 
 @Injectable()
 export class Metrics_Svc {
-	private currentPageData: any;
-	private metricsConfigs: any;
-	private metricsFired: any;
-	private metricsInstances: any = {};
+    private metricsConfigs: any;
+    private metricsFired: any;
+    private metricsInstances: any = {};
+    private routerEventSub: Subscription;
 
-	constructor(private configSvc: Config_Svc) {
-		if (ENV !== 'production') {
-			console.log('Metrics are disabled when not in production mode.');
-			return;
-		}
+    constructor(private router: Router) {
+        if (ENV !== 'production' && ENV !== 'prod') {
+            console.log('Metrics are disabled when not in production mode.');
+            return;
+        }
 
-		configSvc.pageConfigUpdate
-			.subscribe(data => {
-				this.handlePageLoad(data);
-			});
-	}
+        this.routerEventSub = this.router.events
+            .filter(evt => evt instanceof NavigationEnd)
+            .subscribe(evt => {
+                this.onNavigationEnd(evt);
+            });
+    }
 
-	init(metrics) {
-		if (ENV !== 'production') {
-			return;
-		}
+    init(metrics) {
+        if (ENV !== 'production' && ENV !== 'prod') {
+            return;
+        }
 
-		this.metricsConfigs = metrics;
-		this.initMetrics();
-	}
+        this.metricsConfigs = metrics;
+        this.initMetrics();
+    }
 
-	private handlePageLoad(data: any) {
-		let instances = this.metricsInstances;
+    private onNavigationEnd(evt: any) {
+        let instances = this.metricsInstances;
 
-		this.metricsFired = {};
-		this.currentPageData = data;
+        this.metricsFired = {};
 
-		for (let type in instances) {
-			if (instances.hasOwnProperty(type)) {
-				this.firePageLoad(type);
-			}
-		}
-	}
+        for (let type in instances) {
+            if (instances.hasOwnProperty(type)) {
+                this.firePageLoad(type);
+            }
+        }
+    }
 
-	private firePageLoad(type: string) {
-		if (!this.metricsFired || this.metricsFired[type]) {
-			return;
-		}
+    private firePageLoad(type: string) {
+        if (!this.metricsFired || this.metricsFired[type]) {
+            return;
+        }
 
-		let instances = this.metricsInstances;
-		let data = this.currentPageData;
-		this.metricsFired[type] = true;
+        let instances = this.metricsInstances;
+        this.metricsFired[type] = true;
 
-		switch (type) {
-			case MetricTypes.google:
-				let ga = instances[type];
-				ga('set', 'pageview', data.currentRoute.url);
-				ga('send', 'pageview');
-				break;
-		}
-	}
+        switch (type) {
+            case MetricTypes.google:
+                let ga = instances[type];
+                ga('set', 'pageview', this.router.routerState.snapshot.url);
+                ga('send', 'pageview');
+                break;
+        }
+    }
 
-	private initMetrics() {
-		let instances = this.metricsInstances;
-		let cfgs = this.metricsConfigs;
+    private initMetrics() {
+        let instances = this.metricsInstances;
+        let cfgs = this.metricsConfigs;
 
-		for (let cfg in cfgs) {
-			if (cfgs.hasOwnProperty(cfg) && !instances[cfg]) {
-				switch (cfg) {
-					case MetricTypes.google:
-						this.loadGoogleAnalytics();
-						break;
-				}
-			}
-		}
-	}
+        for (let cfg in cfgs) {
+            if (cfgs.hasOwnProperty(cfg) && !instances[cfg]) {
+                switch (cfg) {
+                    case MetricTypes.google:
+                        this.loadGoogleAnalytics();
+                        break;
+                }
+            }
+        }
+    }
 
-	private loadGoogleAnalytics() {
-		let cb = this.onGoogleLoad.bind(this);
-		(function (i, s, o, g, r, a, m) {
-			i['GoogleAnalyticsObject'] = r;
-			i[r] = i[r] || function () {
-					(i[r].q = i[r].q || []).push(arguments)
-				}, i[r].l = 1 * <any>(new Date());
-			a = s.createElement(o),
-				m = s.getElementsByTagName(o)[0];
-			a.async = 1;
-			a.src = g;
-			a.onload = cb;
-			m.parentNode.insertBefore(a, m)
-		})(window, document, 'script', MetricScriptUrls.google, 'ga');
-	}
+    private loadGoogleAnalytics() {
+        let cb = this.onGoogleLoad.bind(this);
+        (function (i, s, o, g, r, a, m) {
+            i['GoogleAnalyticsObject'] = r;
+            i[r] = i[r] || function () {
+                (i[r].q = i[r].q || []).push(arguments)
+            }, i[r].l = 1 * <any>(new Date());
+            a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0];
+            a.async = 1;
+            a.src = g;
+            a.onload = cb;
+            m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', MetricScriptUrls.google, 'ga');
+    }
 
-	private onGoogleLoad() {
-		this.metricsInstances[MetricTypes.google] = ga;
-		ga('create', this.metricsConfigs.google.trackingId, 'auto');
-		this.firePageLoad(MetricTypes.google);
-	}
+    private onGoogleLoad() {
+        this.metricsInstances[MetricTypes.google] = ga;
+        ga('create', this.metricsConfigs.google.trackingId, 'auto');
+        this.firePageLoad(MetricTypes.google);
+    }
 }

--- a/app/module/structure/component/structure-builder/structure-builder.cmp.ts
+++ b/app/module/structure/component/structure-builder/structure-builder.cmp.ts
@@ -82,18 +82,17 @@ export class StructureBuilder_Cmp implements OnInit, OnDestroy {
      * @param route
      */
     private onNavigationEnd(route: any) {
+        this.currentRoute = this.router.routerState.snapshot.url;
         //Without routeMap loaded, we can't match routes to data files. Set it to pending.
         if (!this.config) {
-            this.currentRoute = route;
             return;
         }
-
-        let path: string = route && route.url || '';
+        let path: string = this.currentRoute || '';
         if (path[0] === '/') {
             path = path.substring(1);
+            path = path.split('?')[0];
         }
 
-        this.currentRoute = route;
         this.getPageData(path);
     }
 

--- a/config/webpack/common/runtime.cfg.js
+++ b/config/webpack/common/runtime.cfg.js
@@ -54,7 +54,8 @@ module.exports = function (env) {
                 resrcSrc,
                 settingsFilename,
                 settingsFilepath
-            }
+            },
+            version: pkg.version
         };
     }
 

--- a/config/webpack/common/webpack.base.cfg.js
+++ b/config/webpack/common/webpack.base.cfg.js
@@ -54,15 +54,15 @@ module.exports = function (env) {
         }),
         new DefinePlugin({
             'BREAKPOINT': cfg.breakpoint,
-            'ENV': JSON.stringify(cfg.ENV),
+            'ENV': JSON.stringify(process.env.ENV),
             'VERSION': JSON.stringify(cfg.version),
             'CONTENT_ROOT': JSON.stringify(cfg.path.contentRoot),
             'DATA_ROOT': JSON.stringify(cfg.path.dataRoot),
             'FONT_RELATIVE_PATH': JSON.stringify(cfg.appSettings.url.relative.font),
             'IMAGE_RELATIVE_PATH': JSON.stringify(cfg.appSettings.url.relative.image),
             'process.env': {
-                'ENV': JSON.stringify(cfg.ENV),
-                'NODE_ENV': JSON.stringify(cfg.ENV)
+                'ENV': JSON.stringify(process.env.ENV),
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV)
             }
         }),
         new CopyResourcesPlugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lm-generator-base",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Base site generator",
   "main": "index.js",
   "dependencies": {

--- a/resources-example/resources/.htaccess
+++ b/resources-example/resources/.htaccess
@@ -1,4 +1,4 @@
-RewriteEngine on
+Header set Access-Control-Allow-Origin "*"
 RewriteEngine on
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME} !-f


### PR DESCRIPTION
Add version to app's global runtime config. Fix breaks caused by router upgrade (more may need to happen but for now app seems stable). Also this fixes ENV pointers that broke the metrics service ('prod' and 'production' are now both valid 'production' environment aliases for webpack configs). App now outputs version number on bootstrap. Minor formatting fixes here and there. Fix example HTaccess policy to actually work. Probably not a good idea to whitelist everything but need to figure out a better functioninig policy at a later time.